### PR TITLE
Migrate to .net 5

### DIFF
--- a/CipherCombination.sln
+++ b/CipherCombination.sln
@@ -1,8 +1,22 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TranspositionCipher", "TranspositionCipher\TranspositionCipher\TranspositionCipher.csproj", "{7807D0EA-8A2B-4941-8423-6C77B75F5F0B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Vigenere", "Vigenere\Vigenere\Vigenere.csproj", "{CAEC0445-85A2-412F-A1B5-97C51D853529}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7807D0EA-8A2B-4941-8423-6C77B75F5F0B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7807D0EA-8A2B-4941-8423-6C77B75F5F0B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7807D0EA-8A2B-4941-8423-6C77B75F5F0B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7807D0EA-8A2B-4941-8423-6C77B75F5F0B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CAEC0445-85A2-412F-A1B5-97C51D853529}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CAEC0445-85A2-412F-A1B5-97C51D853529}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CAEC0445-85A2-412F-A1B5-97C51D853529}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CAEC0445-85A2-412F-A1B5-97C51D853529}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/TranspositionCipher/TranspositionCipher.sln
+++ b/TranspositionCipher/TranspositionCipher.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.28307.1145
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TranspositionCipherForm", "TranspositionCipherForm\TranspositionCipherForm.csproj", "{7FBBE6C8-AEFC-422E-A6C4-AD7F48AD0D1B}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TranspositionCipher", "TranspositionCipher\TranspositionCipher.csproj", "{D55AE8FC-97C8-4AE4-97BE-570FBF8413EE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -11,10 +11,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{7FBBE6C8-AEFC-422E-A6C4-AD7F48AD0D1B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{7FBBE6C8-AEFC-422E-A6C4-AD7F48AD0D1B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7FBBE6C8-AEFC-422E-A6C4-AD7F48AD0D1B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{7FBBE6C8-AEFC-422E-A6C4-AD7F48AD0D1B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D55AE8FC-97C8-4AE4-97BE-570FBF8413EE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D55AE8FC-97C8-4AE4-97BE-570FBF8413EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D55AE8FC-97C8-4AE4-97BE-570FBF8413EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D55AE8FC-97C8-4AE4-97BE-570FBF8413EE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TranspositionCipher/TranspositionCipher/TranspositionCipher.cs
+++ b/TranspositionCipher/TranspositionCipher/TranspositionCipher.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TranspositionCipher
+{
+    public static class TranspositionCipher
+    {
+        private static int[] GetShiftIndexes(string key)
+        {
+            int keyLength = key.Length;
+            int[] indexes = new int[keyLength];
+            List<KeyValuePair<int, char>> sortedKey = new List<KeyValuePair<int, char>>();
+            int i;
+
+            for (i = 0; i < keyLength; ++i)
+                sortedKey.Add(new KeyValuePair<int, char>(i, key[i]));
+
+            sortedKey.Sort(
+                delegate (KeyValuePair<int, char> pair1, KeyValuePair<int, char> pair2) {
+                    return pair1.Value.CompareTo(pair2.Value);
+                }
+            );
+
+            for (i = 0; i < keyLength; ++i)
+                indexes[sortedKey[i].Key] = i;
+
+            return indexes;
+        }
+
+        public static string Encipher(string input, string key, char padChar)
+        {
+            input = (input.Length % key.Length == 0) ? input : input.PadRight(input.Length - (input.Length % key.Length) + key.Length, padChar);
+            StringBuilder output = new StringBuilder();
+            int totalChars = input.Length;
+            int totalColumns = key.Length;
+            int totalRows = (int)Math.Ceiling((double)totalChars / totalColumns);
+            char[,] rowChars = new char[totalRows, totalColumns];
+            char[,] colChars = new char[totalColumns, totalRows];
+            char[,] sortedColChars = new char[totalColumns, totalRows];
+            int currentRow, currentColumn, i, j;
+            int[] shiftIndexes = GetShiftIndexes(key);
+
+            for (i = 0; i < totalChars; ++i)
+            {
+                currentRow = i / totalColumns;
+                currentColumn = i % totalColumns;
+                rowChars[currentRow, currentColumn] = input[i];
+            }
+
+            for (i = 0; i < totalRows; ++i)
+                for (j = 0; j < totalColumns; ++j)
+                    colChars[j, i] = rowChars[i, j];
+
+            for (i = 0; i < totalColumns; ++i)
+                for (j = 0; j < totalRows; ++j)
+                    sortedColChars[shiftIndexes[i], j] = colChars[i, j];
+
+            for (i = 0; i < totalChars; ++i)
+            {
+                currentRow = i / totalRows;
+                currentColumn = i % totalRows;
+                output.Append(sortedColChars[currentRow, currentColumn]);
+            }
+
+            return output.ToString();
+        }
+
+        public static string Decipher(string input, string key)
+        {
+            StringBuilder output = new StringBuilder();
+            int totalChars = input.Length;
+            int totalColumns = (int)Math.Ceiling((double)totalChars / key.Length);
+            int totalRows = key.Length;
+            char[,] rowChars = new char[totalRows, totalColumns];
+            char[,] colChars = new char[totalColumns, totalRows];
+            char[,] unsortedColChars = new char[totalColumns, totalRows];
+            int currentRow, currentColumn, i, j;
+            int[] shiftIndexes = GetShiftIndexes(key);
+
+            for (i = 0; i < totalChars; ++i)
+            {
+                currentRow = i / totalColumns;
+                currentColumn = i % totalColumns;
+                rowChars[currentRow, currentColumn] = input[i];
+            }
+
+            for (i = 0; i < totalRows; ++i)
+                for (j = 0; j < totalColumns; ++j)
+                    colChars[j, i] = rowChars[i, j];
+
+            for (i = 0; i < totalColumns; ++i)
+                for (j = 0; j < totalRows; ++j)
+                    unsortedColChars[i, j] = colChars[i, shiftIndexes[j]];
+
+            for (i = 0; i < totalChars; ++i)
+            {
+                currentRow = i / totalRows;
+                currentColumn = i % totalRows;
+                output.Append(unsortedColChars[currentRow, currentColumn]);
+            }
+
+            return output.ToString();
+        }
+    }
+}

--- a/TranspositionCipher/TranspositionCipher/TranspositionCipher.csproj
+++ b/TranspositionCipher/TranspositionCipher/TranspositionCipher.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net5.0</TargetFramework>
+    </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Pekerjaan pada branch ini:

- Memindahkan implementasi transposition cipher ke .NET class library
- Menambahkan reference kedua project cipher dalam top-level solution

Alasan migrasi ke .NET adalah Rider tidak dapat membuka solution yang berisi project dengan framework berbeda. Pada awalnya project transposition cipher menggunakan .NET Framework. Sedangkan framework yang akan digunakan untuk solution CipherCombination ini adalah .NET.